### PR TITLE
Improve Netlify debug logging

### DIFF
--- a/docs/netlify-debugging.md
+++ b/docs/netlify-debugging.md
@@ -1,0 +1,13 @@
+# Netlify Production Error Debugging
+
+The `TypeError: Cannot read properties of undefined (reading 'forwardRef')` error may stem from a number of places. Below are several potential sources that were investigated:
+
+1. **Mismatched React versions** between dependencies or the bundler output.
+2. **Tree-shaking or bundling issues** causing React to be excluded from the vendor bundle.
+3. **Improper module resolution** where a library expects React in the global scope.
+4. **Minification or build optimizations** altering code that relies on `forwardRef`.
+5. **Third-party component libraries** referencing a different React instance.
+6. **Service worker caching** serving outdated assets after deployments.
+7. **Incorrect environment variables** leading to production-specific bugs.
+
+From these possibilities, the most likely culprits are bundling issues and third-party libraries referencing their own React copy. To help validate this, additional runtime logs now output the React version, the type of `React.forwardRef`, and any existing `window.React` reference. These logs should appear in Netlify's production console to aid further debugging.

--- a/index.html
+++ b/index.html
@@ -73,6 +73,9 @@
       // Global error handler
       window.addEventListener('error', function(event) {
         console.error('Global error:', event.error);
+        console.log('Debug: window.React availability', (window as any).React);
+        console.log('Debug: userAgent', navigator.userAgent);
+        console.log('Debug: location', window.location.href);
         const root = document.getElementById('root');
         if (root) {
           try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,13 @@ import App from './App';
 import './index.css';
 import { register } from './service-worker-registration';
 
+// Early runtime check to validate React availability in production builds
+if (typeof window !== 'undefined') {
+  console.log('Debug: React version', (React as any).version);
+  console.log('Debug: typeof React.forwardRef', typeof (React as any).forwardRef);
+  console.log('Debug: existing window.React', (window as any).React);
+}
+
 // Simple loading component
 const LoadingFallback = () => (
   <div style={{


### PR DESCRIPTION
## Summary
- log React version and `forwardRef` availability during boot
- include environment details when the global error handler fires
- capture likely Netlify error causes in new doc

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'sharp')*